### PR TITLE
Apply password and username obfuscation at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+JFLAGS = -Xdiags:verbose
+
+LIB = lib/guava-21.0.jar
+
+all: src/speco/Hack.class
+
+src/%.class: src/%.java
+	javac $(JFLAGS) -cp $(LIB) $^
+
+.PHONY: clean
+clean:
+	$(RM) src/speco/*.class
+
+.PHONY: run
+run: src/speco/Hack.class
+	java -cp $(LIB):src/ speco.Hack


### PR DESCRIPTION
It appears that the protocol employs some sort of username and password obfuscation using XOR with a pattern contained within the the same message. This change makes it explicit how that mechanism seems to operate and also allows for guessing alternative usernames and non-numeric passwords.

Although this change opens more feature possibilities, it does not contain any functional changes.